### PR TITLE
Feature: Platform manager can browse orders

### DIFF
--- a/app/platform-manager/index.tsx
+++ b/app/platform-manager/index.tsx
@@ -1,0 +1,122 @@
+import { Text, View, StyleSheet, Pressable, FlatList, ActivityIndicator } from "react-native";
+import { useRouter } from "expo-router";
+import { useState, useEffect } from "react";
+import { supabase } from "@/lib/supabase";
+
+//could be moved to a .ts file
+type Order = {
+  id: string;
+  created_at: string;
+  updated_at: string;
+  user: string | null;
+  paid_at: string | null;
+  accepted_at: string | null;
+  ready_at: string | null;
+  driver_collected_at: string | null;
+  delivered_at: string | null;
+  collected_at: string | null;
+  completed_at: string | null;
+  cancelled_at: string | null;
+  total_cost: number;
+  total_items: number;
+  pickup_window: string | null;
+  comments: string | null;
+  points_redeemed: number;
+  points_earned: number;
+};
+
+export default function Index() {
+  const router = useRouter();
+  const [orders, setOrders] = useState<Order[]>([]);;
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchOrders();
+  }, []);
+
+  const fetchOrders = async () => {
+    try {
+        setLoading(true);
+        const { data, error } = await supabase
+            .from("order")
+            .select("*");
+
+        if (error) throw error;
+
+        const sortedData = data;
+
+        setOrders(sortedData);
+        console.log("Fetched orders:", data);
+    } catch (error) {
+        console.error("Error fetching orders:", error);
+    } finally {
+        setLoading(false);
+    }
+  };
+
+  const renderItem = ({ item }: { item: Order }) => (
+    <View style={styles.item}>
+      <Text style={styles.itemText}>Order ID: {item.id}</Text>
+      <Text style={styles.itemText}>Total: ${item.total_cost?.toFixed(2)}</Text>
+      <Text style={styles.itemText}>Items: {item.total_items}</Text>
+      <Text style={styles.itemText}>Created: {new Date(item.created_at).toLocaleString()}</Text>
+    </View>
+  );
+
+  return (
+    <View style={styles.container}>
+      <Pressable style={styles.button} onPress={() => router.push("/")}>
+        <Text style={styles.buttonText}>Home</Text>
+      </Pressable>
+
+
+      {loading ? (
+        <ActivityIndicator size="large" color="#00BFA6" />
+      ) : (
+        <FlatList
+          data={orders}
+          renderItem={renderItem}
+          keyExtractor={(item) => item.id}
+          contentContainerStyle={styles.list}
+        />
+      )}
+    
+
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  button: {
+    backgroundColor: "#00BFA6",
+    paddingVertical: 20,
+    paddingHorizontal: 40,
+    borderRadius: 8,
+    margin: 6,
+  },
+  buttonText: {
+    color: "#fff",
+    fontSize: 18,
+    fontWeight: "bold",
+    textAlign: "center",
+  },
+  item: {
+    backgroundColor: "#f0f0f0",
+    padding: 16,
+    marginVertical: 8,
+    borderRadius: 8,
+    width: "90%",
+  },
+  itemText: {
+    fontSize: 16,
+    color: "#333",
+  },
+  list: {
+    padding: 10,
+  }
+});

--- a/app/platform-manager/index.tsx
+++ b/app/platform-manager/index.tsx
@@ -28,6 +28,7 @@ type Order = {
 export default function Index() {
   const router = useRouter();
   const [orders, setOrders] = useState<Order[]>([]);;
+  const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -36,39 +37,54 @@ export default function Index() {
 
   const fetchOrders = async () => {
     try {
-        setLoading(true);
-        const { data, error } = await supabase
-            .from("order")
-            .select("*");
+      setLoading(true);
+      const { data, error } = await supabase.from("order").select("*");
+      
+      if (error) throw error;
+      
+      //for future sorting
+      const sortedData = data;
 
-        if (error) throw error;
-
-        const sortedData = data;
-
-        setOrders(sortedData);
-        console.log("Fetched orders:", data);
+      setOrders(sortedData);
+      console.log("Fetched orders:", data);
     } catch (error) {
-        console.error("Error fetching orders:", error);
+      console.error("Error fetching orders:", error);
     } finally {
-        setLoading(false);
+      setLoading(false);
     }
   };
 
+  const renderHeader = () => (
+    <View style={[styles.row, styles.headerRow]}>
+      <Text style={[styles.headerText]}>Order ID</Text>
+      <Text style={[styles.headerText]}>Pickup Window</Text>
+      <Text style={[styles.headerText]}>Delivered at</Text>
+      <Text style={[styles.headerText]}>Collected at</Text>
+      <Text style={[styles.headerText]}>Comments</Text>
+    </View>
+  );
+
   const renderItem = ({ item }: { item: Order }) => (
     <View style={styles.item}>
-      <Text style={styles.itemText}>Order ID: {item.id}</Text>
-      <Text style={styles.itemText}>Total: ${item.total_cost?.toFixed(2)}</Text>
-      <Text style={styles.itemText}>Items: {item.total_items}</Text>
-      <Text style={styles.itemText}>Created: {new Date(item.created_at).toLocaleString()}</Text>
+      <View style={styles.row}>
+        <Text style={styles.itemText}>{item.id}</Text>
+        <Text style={styles.itemText}>{item.pickup_window}</Text>
+        <Text style={styles.itemText}>
+          {item.delivered_at ? new Date(item.delivered_at).toLocaleString() : "N/A"}
+        </Text>
+        <Text style={styles.itemText}>
+          {item.collected_at ? new Date(item.collected_at).toLocaleString() : "N/A"}
+        </Text>
+        <Text style={styles.itemText}>{item.comments}</Text>
+      </View>
     </View>
   );
 
   return (
     <View style={styles.container}>
-      <Pressable style={styles.button} onPress={() => router.push("/")}>
+      <Pressable style={[styles.button, styles.homeButton]} onPress={() => router.push("/")}>
         <Text style={styles.buttonText}>Home</Text>
       </Pressable>
-
 
       {loading ? (
         <ActivityIndicator size="large" color="#00BFA6" />
@@ -76,12 +92,11 @@ export default function Index() {
         <FlatList
           data={orders}
           renderItem={renderItem}
+          ListHeaderComponent={renderHeader}
           keyExtractor={(item) => item.id}
           contentContainerStyle={styles.list}
         />
       )}
-    
-
     </View>
   );
 }
@@ -90,7 +105,12 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     justifyContent: "center",
-    alignItems: "center",
+    alignItems: "stretch",
+    width: "100%",
+  },
+
+  homeButton: {
+    alignSelf: "center",
   },
   button: {
     backgroundColor: "#00BFA6",
@@ -110,13 +130,36 @@ const styles = StyleSheet.create({
     padding: 16,
     marginVertical: 8,
     borderRadius: 8,
-    width: "90%",
+    width: "100%",
+  },
+  row: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "space-between",
+    alignItems: "center",
+    width: "100%",
   },
   itemText: {
     fontSize: 16,
     color: "#333",
+    flex: 1,
+    textAlign: "left",
   },
   list: {
     padding: 10,
-  }
+    width: "100%",
+  },
+  headerRow: {
+    backgroundColor: "#e0e0e0",
+    padding: 8,
+    borderRadius: 8,
+  },
+  headerText: {
+    flex: 1,
+    textAlign: "left",
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#333",
+  },
+
 });

--- a/app/platform-manager/index.tsx
+++ b/app/platform-manager/index.tsx
@@ -27,7 +27,6 @@ type Order = {
 
 export default function Index() {
   const router = useRouter();
-  const [orders, setOrders] = useState<Order[]>([]);;
   const [orders, setOrders] = useState<Order[]>([]);
   const [loading, setLoading] = useState(true);
 


### PR DESCRIPTION
As a platform manager I want to view all current orders so that I can monitor their status

- [ ] Given I am a platform manager, when I access the orders dashboard, then I should see a list of all active orders with relevant information such as order ID, pickup point, pickup window, delivered/collected status, comments, etc
- [ ] Given I am a platform manager, when I search order ID, then I should be brought straight to the order I am searching for

More thorough sorting (include/exclude, sort by field) has yet to be added. However all the necessary requirements to implement should already be in place (SQL Query by date, etc (assumes Order table created_at field is same date as order pickup). Just uncomment out the labelled parts in Supabase)

Needs more thorough testing as can't check scroll feature with the current limited dataset